### PR TITLE
Add functionality to clear all inline styles by passing in an empty object

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Basic usage is as follows:
     // Or with a CSS function
     S(myHTMLElement)('transform', ['translate', '50%', '50%']);
 
+    // Clear all inline styles with an empty object
+    S(myHTMLElement)({})
+
 Note that, the wrapper function will cache the computed styles. It will
 remove the cache when something is written. Do not set styles from elsewhere
 or else the cache will become invalid!

--- a/dist/style.js
+++ b/dist/style.js
@@ -62,11 +62,24 @@ function Style(el){
         el.style[cProp] = value;
     }
 
+    function reset() {
+        var cssText = el.style.cssText;
+        var keys = cssText.split("; ").map(function(string) {
+            return string.split(": ")[0];
+        });
+
+        for (var index in keys) {
+            el.style[keys[index]] = "";
+        }
+    }
+
     function proxy(prop, rules){
         if (arguments.length == 1) {
             if (typeof prop == 'string')
                 return read(prop);
-            else for (var i in prop)
+            else if (typeof prop == 'object' && Object.keys(prop).length === 0) {
+                reset();
+            } else for (var i in prop)
                 write(i, prop[i]);
         } else {
             write(prop, rules);

--- a/test/all.js
+++ b/test/all.js
@@ -91,3 +91,14 @@ test('write CSS function as an array pixelifies numbers', function(){
 
     equal(el.style.top, 'calc(225px)');
 });
+
+test('clear inline styles with empty object', function() {
+    S(el)({height: "100%", width: "100%"});
+
+    equal(el.style.cssText, 'height: 100%; width: 100%;');
+
+    S(el)({});
+
+    equal(el.style.height, '');
+    equal(el.style.width, '');
+})


### PR DESCRIPTION
This PR includes functionality to clear the inline styles from an element by passing the `S` instance an empty object.
